### PR TITLE
Fixed NullPointerException

### DIFF
--- a/addons/binding/org.openhab.binding.bosesoundtouch/src/main/java/org/openhab/binding/bosesoundtouch/internal/ContentItem.java
+++ b/addons/binding/org.openhab.binding.bosesoundtouch/src/main/java/org/openhab/binding/bosesoundtouch/internal/ContentItem.java
@@ -64,11 +64,7 @@ public class ContentItem {
         if (getOperationMode() == OperationModeType.STANDBY) {
             return true;
         }
-        if (itemName.equals("") || source.equals("")) {
-            return false;
-        } else {
-            return true;
-        }
+        return !"".equals(itemName) && !"".equals(source);
     }
 
     /**
@@ -92,10 +88,7 @@ public class ContentItem {
             if (!isEqual(other.location, this.location)) {
                 return false;
             }
-            if (!isEqual(other.itemName, this.itemName)) {
-                return false;
-            }
-            return true;
+            return isEqual(other.itemName, this.itemName);
         }
         return super.equals(obj);
     }


### PR DESCRIPTION
I've got a NPE in my Logfile:
[dtouch.handler.BoseSoundTouchHandler] - SoundTouch 10: Could not parse XML from string '<updates deviceID="xxx"><nowPlayingUpdated><nowPlaying deviceID="xxx" source="INTERNET_RADIO"><ContentItem source="INTERNET_RADIO" location="" sourceAccount="" isPresetable="true"><itemName></itemName><containerArt></containerArt></ContentItem><track></tr
ack><artist></artist><album></album><stationName></stationName><art artImageStatus="INVALID" /><playStatus>BUFFERING_STATE</playStatus><description>   kbps  ,  </description><stationLocation></stat
ionLocation></nowPlaying></nowPlayingUpdated></updates>'; exception is:
java.lang.NullPointerException: null
        at org.openhab.binding.bosesoundtouch.internal.ContentItem.isValid(ContentItem.java:71) [238:org.openhab.binding.bosesoundtouch:2.1.0.201710101925]
        at org.openhab.binding.bosesoundtouch.internal.CommandExecutor.setCurrentContentItem(CommandExecutor.java:131) [238:org.openhab.binding.bosesoundtouch:2.1.0.201710101925]
        at org.openhab.binding.bosesoundtouch.internal.XMLResponseHandler.endElement(XMLResponseHandler.java:385) [238:org.openhab.binding.bosesoundtouch:2.1.0.201710101925]

